### PR TITLE
Added additional parameters to Message class

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 [![Total Downloads](https://poser.pugx.org/paragraph1/php-fcm/downloads)](https://packagist.org/packages/paragraph1/php-fcm)
 [![License](https://poser.pugx.org/paragraph1/php-fcm/license)](https://packagist.org/packages/paragraph1/php-fcm)
 
+
+A fork of the phpFCM project. See the original at: https://github.com/Paragraph1/php-fcm
+
+
 PHP application server implementation for Firebase Cloud Messaging.
 - supports device and topic messages
 - currently this app server library only supports sending Messages/Notifications via HTTP.

--- a/src/Client.php
+++ b/src/Client.php
@@ -62,6 +62,9 @@ class Client implements ClientInterface
      */
     public function send(Message $message)
     {
+        $messageArray = json_decode(json_encode($message->jsonSerialize()), true); // Ensure an array.
+        $body = array_merge($messageArray, $message->getAdditionalParameters());
+
         return $this->guzzleClient->post(
             $this->getApiUrl(),
             [
@@ -69,7 +72,7 @@ class Client implements ClientInterface
                     'Authorization' => sprintf('key=%s', $this->apiKey),
                     'Content-Type' => 'application/json'
                 ],
-                'body' => json_encode($message)
+                'body' => $body
             ]
         );
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -63,7 +63,7 @@ class Client implements ClientInterface
     public function send(Message $message)
     {
         $messageArray = json_decode(json_encode($message->jsonSerialize()), true); // Ensure an array.
-        $body = array_merge($messageArray, $message->getAdditionalParameters());
+        $jsonArray = array_merge($messageArray, $message->getAdditionalParameters());
 
         return $this->guzzleClient->post(
             $this->getApiUrl(),
@@ -72,7 +72,7 @@ class Client implements ClientInterface
                     'Authorization' => sprintf('key=%s', $this->apiKey),
                     'Content-Type' => 'application/json'
                 ],
-                'body' => $body
+                'json' => $jsonArray
             ]
         );
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -226,11 +226,14 @@ class Message implements \JsonSerializable
     /**
      * A convenient way for setting additional parameters in a generic array,
      * instead of adding a new property for each new parameter.
-     * 
+     *
      * @example Example: you can set specific info like android_channel_id or sound. See more at: https://firebase.google.com/docs/cloud-messaging/http-server-ref
      * Usage: $message->setAdditionalParameters('android_channel_id', 'YOUR_CHANNEL_ID');
-     * 
-     * @var array
+     *
+     *
+     * @param $key
+     * @param $value
+     * @return Message
      */
     public function setAdditionalParameters($key, $value)
     {

--- a/src/Message.php
+++ b/src/Message.php
@@ -37,6 +37,17 @@ class Message implements \JsonSerializable
     private $contentAvailableFlag;
 
     /**
+     * This is just a convenient and generic array for setting additional parameters,
+     * instead of adding a new property for each new parameter.
+     * 
+     * @example Example: you can set specific info like android_channel_id or sound. See more at: https://firebase.google.com/docs/cloud-messaging/http-server-ref
+     * Usage: $message->setAdditionalParameters('android_channel_id', 'YOUR_CHANNEL_ID');
+     * 
+     * @var array
+     */
+    private $additionalParameters = [];
+
+    /**
      * where should the message go
      *
      * @param Recipient $recipient
@@ -211,4 +222,29 @@ class Message implements \JsonSerializable
                 }
         }
     }
+
+    /**
+     * A convenient way for setting additional parameters in a generic array,
+     * instead of adding a new property for each new parameter.
+     * 
+     * @example Example: you can set specific info like android_channel_id or sound. See more at: https://firebase.google.com/docs/cloud-messaging/http-server-ref
+     * Usage: $message->setAdditionalParameters('android_channel_id', 'YOUR_CHANNEL_ID');
+     * 
+     * @var array
+     */
+    public function setAdditionalParameters($key, $value)
+    {
+        $this->additionalParameters[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAdditionalParameters()
+    {
+        return $this->additionalParameters;
+    }
+
 }


### PR DESCRIPTION
It was added a new property to Message class, a generic array to avoid the need of creating a new property each time that some configuration get changed in Firebase. Me and my team find out this need when we needed to add a new querystring parameter on firebase requests, the android_channel_id. So, instead of creating a new property called androidChannelId (or whatever) in the Message class, I created the additionalParameters array, so we can put into it any parameters we want.